### PR TITLE
feature: todo app collaboration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,14 @@
 # Rules
 
+## Thoughts and Summaries
+
+- For saving you thoughts or summaries use .md extension files, save them in .ai folder in appropriate folder. If folder does not exist, create it.
+- Appropriate folder for .md thoughts/summaries should be the name of the feature/fix/improvement you are working on right now. .md files names convention:
+  - requirements.md - for requirements of the feature - these should be buisness requirements, not technical ones
+  - initial-notes.md - my for initial notes about the feature
+  - development-plan.md - for development plan of the feature, this should be technical plan, based on business requirements
+  - step-x.md - for each step of the feature development, where x is the number of the step
+
 ## General Guidelines
 
 - Project uses poetry for dependency management

--- a/alembic/versions/d6d81a0ff5fa_add_todo_project_ownership_and_.py
+++ b/alembic/versions/d6d81a0ff5fa_add_todo_project_ownership_and_.py
@@ -1,0 +1,174 @@
+"""add_todo_project_ownership_and_collaboration
+
+Revision ID: d6d81a0ff5fa
+Revises: 3a778cea0867
+Create Date: 2025-08-06 18:55:27.660808
+
+"""
+from typing import Sequence, Union
+import uuid
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd6d81a0ff5fa'
+down_revision: Union[str, None] = '3a778cea0867'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema and migrate data."""
+    # Create todo_project_collaborators table
+    op.create_table('todo_project_collaborators',
+                    sa.Column('project_id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', postgresql.UUID(
+                        as_uuid=True), nullable=False),
+                    sa.Column('created_at', sa.DateTime(), nullable=False,
+                              server_default=sa.text('now()')),
+                    sa.Column('updated_at', sa.DateTime(), nullable=False,
+                              server_default=sa.text('now()')),
+                    sa.ForeignKeyConstraint(
+                        ['project_id'], ['todo_projects.id'], ondelete='CASCADE'),
+                    sa.ForeignKeyConstraint(
+                        ['user_id'], ['users.id'], ondelete='CASCADE'),
+                    sa.PrimaryKeyConstraint('project_id', 'user_id'),
+                    sa.UniqueConstraint('project_id', 'user_id',
+                                        name='unique_project_user_collaboration')
+                    )
+
+    # Add columns to todo_projects with nullable=True initially
+    with op.batch_alter_table('todo_projects', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('owner_id', sa.UUID(), nullable=True))
+        batch_op.add_column(
+            sa.Column('is_general', sa.Boolean(), server_default='false', nullable=False))
+        batch_op.drop_constraint('todo_projects_name_key', type_='unique')
+
+    # Get default owner ID (different for dev and prod)
+    conn = op.get_bind()
+
+    # Fallback to first admin user if specified email not found
+    result = conn.execute(text("SELECT id FROM users LIMIT 1"))
+    default_owner_row = result.fetchone()
+    default_owner_id = default_owner_row[0] if default_owner_row else None
+
+    # Set default owner for all existing todo_projects
+    conn.execute(
+        text(f"UPDATE todo_projects SET owner_id = '{default_owner_id}'"))
+
+    # Create "General" projects for all users
+    result = conn.execute(text("SELECT id, email FROM users"))
+    users_data = result.fetchall()
+    now = datetime.now().isoformat()
+
+    general_projects = {}
+    for user_row in users_data:
+        user_id = user_row[0]
+        email = user_row[1]
+
+        # Check if user already has a project
+        result = conn.execute(
+            text(f"SELECT id FROM todo_projects WHERE owner_id = '{user_id}' LIMIT 1"))
+        existing_project = result.fetchone()
+
+        if not existing_project:
+            # Create a "General" project for this user
+            result = conn.execute(
+                text(f"INSERT INTO todo_projects (name, created_at, updated_at, owner_id, is_general) "
+                     f"VALUES ('General', '{now}', '{now}', '{user_id}', TRUE) RETURNING id")
+            )
+            new_project = result.fetchone()
+            if new_project:
+                general_projects[str(user_id)] = new_project[0]
+
+    # Get all user's general projects for item assignments
+    for user_row in users_data:
+        user_id = user_row[0]
+        user_id_str = str(user_id)
+
+        if user_id_str not in general_projects:
+            result = conn.execute(
+                text(
+                    f"SELECT id FROM todo_projects WHERE owner_id = '{user_id}' AND is_general = TRUE LIMIT 1")
+            )
+            general_project = result.fetchone()
+
+            if general_project:
+                general_projects[user_id_str] = general_project[0]
+
+    # Assign orphaned items to owner's general project
+    result = conn.execute(
+        text("SELECT id FROM todo_items WHERE project_id IS NULL"))
+    orphaned_items = result.fetchall()
+
+    if orphaned_items and default_owner_id:
+        # Make sure we have a General project for the default owner
+        if str(default_owner_id) not in general_projects:
+            # Create one if it doesn't exist
+            result = conn.execute(
+                text(
+                    f"SELECT id FROM todo_projects WHERE owner_id = '{default_owner_id}' AND is_general = TRUE LIMIT 1")
+            )
+            general_project = result.fetchone()
+
+            if general_project:
+                general_projects[str(default_owner_id)] = general_project[0]
+            else:
+                # Create a new General project for the default owner
+                result = conn.execute(
+                    text(f"INSERT INTO todo_projects (name, created_at, updated_at, owner_id, is_general) "
+                         f"VALUES ('General', '{now}', '{now}', '{default_owner_id}', TRUE) RETURNING id")
+                )
+                new_project = result.fetchone()
+                if new_project:
+                    general_projects[str(default_owner_id)] = new_project[0]
+
+        # Assign to default owner's general project
+        default_general_project = general_projects.get(str(default_owner_id))
+        if default_general_project:
+            for item_row in orphaned_items:
+                item_id = item_row[0]
+                conn.execute(
+                    text(
+                        f"UPDATE todo_items SET project_id = {default_general_project} WHERE id = {item_id}")
+                )
+
+    # Add the foreign key constraints
+    with op.batch_alter_table('todo_projects', schema=None) as batch_op:
+        batch_op.create_foreign_key(None, 'users', ['owner_id'], ['id'])
+        batch_op.alter_column('owner_id', nullable=False)
+
+    # Update todo_items foreign key to CASCADE and make project_id required
+    with op.batch_alter_table('todo_items', schema=None) as batch_op:
+        batch_op.drop_constraint(
+            'todo_items_project_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(None, 'todo_projects', ['project_id'], [
+                                    'id'], ondelete='CASCADE')
+        batch_op.alter_column(
+            'project_id', existing_type=sa.INTEGER(), nullable=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Revert todo_items changes
+    with op.batch_alter_table('todo_items', schema=None) as batch_op:
+        batch_op.alter_column(
+            'project_id', existing_type=sa.INTEGER(), nullable=True)
+        batch_op.drop_constraint(None, type_='foreignkey')
+        batch_op.create_foreign_key('todo_items_project_id_fkey', 'todo_projects', [
+                                    'project_id'], ['id'], ondelete='SET NULL')
+
+    # Revert todo_projects changes
+    with op.batch_alter_table('todo_projects', schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_='foreignkey')
+        batch_op.create_unique_constraint('todo_projects_name_key', ['name'])
+        batch_op.drop_column('is_general')
+        batch_op.drop_column('owner_id')
+
+    # Drop the collaborators table
+    op.drop_table('todo_project_collaborators')

--- a/src/api/v1/deps.py
+++ b/src/api/v1/deps.py
@@ -1,0 +1,109 @@
+"""Dependencies for Todo app collaboration feature."""
+
+from typing import Optional
+from uuid import UUID
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.database import get_db
+from src.auth.jwt_dependencies import get_current_active_user
+from src.models.user import User
+from src.services.todo_access_service import (
+    user_can_access_project,
+    user_can_access_item,
+    user_is_project_owner,
+    is_general_project
+)
+
+
+def require_project_access(project_id: int):
+    """
+    Dependency to require project access (owner or collaborator).
+    Raises HTTPException if user doesn't have access.
+    """
+    async def dependency(
+        current_user: User = Depends(get_current_active_user),
+        db: AsyncSession = Depends(get_db)
+    ):
+        has_access = await user_can_access_project(
+            db, project_id, UUID(str(current_user.id))
+        )
+
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access to this project is forbidden"
+            )
+
+        return current_user
+
+    return dependency
+
+
+def require_project_ownership(project_id: int):
+    """
+    Dependency to require project ownership.
+    Raises HTTPException if user is not the owner.
+    """
+    async def dependency(
+        current_user: User = Depends(get_current_active_user),
+        db: AsyncSession = Depends(get_db)
+    ):
+        is_owner = await user_is_project_owner(
+            db, project_id, UUID(str(current_user.id))
+        )
+
+        if not is_owner:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only project owners can perform this action"
+            )
+
+        return current_user
+
+    return dependency
+
+
+def require_item_access(item_id: int):
+    """
+    Dependency to require access to a todo item.
+    Raises HTTPException if user doesn't have access.
+    """
+    async def dependency(
+        current_user: User = Depends(get_current_active_user),
+        db: AsyncSession = Depends(get_db)
+    ):
+        has_access = await user_can_access_item(
+            db, item_id, UUID(str(current_user.id))
+        )
+
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access to this item is forbidden"
+            )
+
+        return current_user
+
+    return dependency
+
+
+def prevent_general_project_modification(project_id: int):
+    """
+    Dependency to prevent modification of "General" projects.
+    Raises HTTPException if the project is a General project.
+    """
+    async def dependency(
+        db: AsyncSession = Depends(get_db)
+    ):
+        is_general = await is_general_project(db, project_id)
+
+        if is_general:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="The General project cannot be modified or deleted"
+            )
+
+        return True
+
+    return dependency

--- a/src/api/v1/endpoints/todo_items.py
+++ b/src/api/v1/endpoints/todo_items.py
@@ -1,15 +1,18 @@
 from typing import Any, List
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy import desc, asc
+from uuid import UUID
+from typing import Annotated
 
 from src.core.database import get_db
 from src.models.todo_item import TodoItem
 from src.models.todo_project import TodoProject
+from src.models.user import User
 from src.schemas.todo_item import (
     TodoItem as TodoItemSchema,
     TodoItemCreate,
@@ -17,6 +20,11 @@ from src.schemas.todo_item import (
 )
 from src.auth.enums.actions import Actions
 from src.auth.permission_helpers import get_todo_items_permissions
+from src.auth.jwt_dependencies import get_current_active_user
+from src.api.v1.deps import (
+    require_project_access,
+    require_item_access
+)
 
 router = APIRouter()
 
@@ -24,6 +32,7 @@ router = APIRouter()
 @router.get("", response_model=List[TodoItemSchema])
 async def get_todo_items(
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
     skip: int = 0,
     limit: int = 100,
     sort_by: str = Query(
@@ -31,22 +40,64 @@ async def get_todo_items(
     order: str = Query("asc", description="Sort order: asc or desc"),
     _: None = Depends(get_todo_items_permissions(Actions.READ))
 ) -> Any:
-    """Retrieve all todo items."""
+    """Retrieve todo items from projects the user has access to."""
+    from src.services.todo_access_service import get_accessible_project_ids
+
+    # Get all project IDs the user has access to
+    project_ids = await get_accessible_project_ids(db, UUID(str(current_user.id)))
+
     allowed_sort_fields = {"id", "name", "created_at",
                            "updated_at", "is_closed", "completed_at"}
     if sort_by not in allowed_sort_fields:
         raise HTTPException(
             status_code=400, detail=f"Invalid sort_by field: {sort_by}")
+
     order_func = desc if order.lower() == "desc" else asc
     sort_column = getattr(TodoItem, sort_by)
+
+    # Filter items by accessible projects
     result = await db.execute(
         select(TodoItem)
         .options(selectinload(TodoItem.project))
+        .where(TodoItem.project_id.in_(project_ids))
         .order_by(order_func(sort_column))
         .offset(skip)
         .limit(limit)
     )
-    return result.scalars().all()
+
+    items = result.scalars().all()
+
+    # Manually convert items to dict to avoid async relationship issues
+    items_list = []
+    for item in items:
+        # Convert project to dict with string owner_id
+        project_dict = None
+        if item.project:
+            project_dict = {
+                "id": item.project.id,
+                "name": item.project.name,
+                "created_at": item.project.created_at,
+                "updated_at": item.project.updated_at,
+                "owner_id": str(item.project.owner_id),
+                "is_general": item.project.is_general
+            }
+
+        # Convert item to dict
+        item_dict = {
+            "id": item.id,
+            "name": item.name,
+            "description": item.description,
+            "is_closed": item.is_closed,
+            "shops": item.shops,
+            "project_id": item.project_id,
+            "created_at": item.created_at,
+            "updated_at": item.updated_at,
+            "completed_at": item.completed_at,
+            "project": project_dict
+        }
+        items_list.append(item_dict)
+
+    return items_list
 
 
 @router.post("", response_model=TodoItemSchema, status_code=status.HTTP_201_CREATED)
@@ -54,93 +105,272 @@ async def create_todo_item(
     *,
     db: AsyncSession = Depends(get_db),
     item_in: TodoItemCreate,
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_todo_items_permissions(Actions.CREATE))
 ) -> Any:
-    """Create new todo item."""
-    project = None
-    if item_in.project_id:
-        project = await db.get(TodoProject, item_in.project_id)
-        if not project:
-            raise HTTPException(status_code=404, detail="Project not found")
+    """Create new todo item in a project the user has access to."""
+    # Check if project_id is provided
+    if not item_in.project_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="project_id is required"
+        )
+
+    # Check if user has access to the project
+    from src.services.todo_access_service import user_can_access_project
+    project_id = item_in.project_id
+    has_access = await user_can_access_project(
+        db, project_id, UUID(str(current_user.id))
+    )
+
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access to this project is forbidden"
+        )
+
+    # Get the project
+    project = await db.get(TodoProject, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    # Create the item
+    now = datetime.utcnow()
     db_item = TodoItem(
         name=item_in.name,
         description=item_in.description,
         is_closed=False,
         shops=item_in.shops,
-        project=project
+        project_id=project_id,
+        created_at=now,
+        updated_at=now
     )
     db.add(db_item)
     await db.commit()
     # Eagerly load the project relationship after creation
     await db.refresh(db_item, attribute_names=["project"])
-    return db_item
+
+    # Manually convert item to dict to avoid async relationship issues
+    # Convert project to dict with string owner_id
+    project_dict = None
+    if db_item.project:
+        project_dict = {
+            "id": db_item.project.id,
+            "name": db_item.project.name,
+            "created_at": db_item.project.created_at,
+            "updated_at": db_item.project.updated_at,
+            "owner_id": str(db_item.project.owner_id),
+            "is_general": db_item.project.is_general
+        }
+
+    # Convert item to dict
+    item_dict = {
+        "id": db_item.id,
+        "name": db_item.name,
+        "description": db_item.description,
+        "is_closed": db_item.is_closed,
+        "shops": db_item.shops,
+        "project_id": db_item.project_id,
+        "created_at": db_item.created_at,
+        "updated_at": db_item.updated_at,
+        "completed_at": db_item.completed_at,
+        "project": project_dict
+    }
+
+    return item_dict
 
 
 @router.get("/{item_id}", response_model=TodoItemSchema)
 async def get_todo_item(
     *,
     db: AsyncSession = Depends(get_db),
-    item_id: int,
+    item_id: Annotated[int, Path(...)],
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_todo_items_permissions(Actions.READ))
 ) -> Any:
-    """Get todo item by ID."""
+    """Get todo item by ID if the user has access to its project."""
+    # First, get the item
     item = await db.get(TodoItem, item_id, options=[selectinload(TodoItem.project)])
     if not item:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Todo item with ID {item_id} not found"
         )
-    return item
+
+    # Check if user has access to the project
+    from src.services.todo_access_service import user_can_access_project
+    if item.project_id:
+        has_access = await user_can_access_project(
+            db, item.project_id, UUID(str(current_user.id))
+        )
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access to this item is forbidden"
+            )
+
+    # Manually convert item to dict to avoid async relationship issues
+    # Convert project to dict with string owner_id
+    project_dict = None
+    if item.project:
+        project_dict = {
+            "id": item.project.id,
+            "name": item.project.name,
+            "created_at": item.project.created_at,
+            "updated_at": item.project.updated_at,
+            "owner_id": str(item.project.owner_id),
+            "is_general": item.project.is_general
+        }
+
+    # Convert item to dict
+    item_dict = {
+        "id": item.id,
+        "name": item.name,
+        "description": item.description,
+        "is_closed": item.is_closed,
+        "shops": item.shops,
+        "project_id": item.project_id,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+        "completed_at": item.completed_at,
+        "project": project_dict
+    }
+
+    return item_dict
 
 
 @router.put("/{item_id}", response_model=TodoItemSchema)
 async def update_todo_item(
     *,
     db: AsyncSession = Depends(get_db),
-    item_id: int,
+    item_id: Annotated[int, Path(...)],
     item_in: TodoItemUpdate,
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_todo_items_permissions(Actions.UPDATE))
 ) -> Any:
-    """Update a todo item."""
+    """Update a todo item if the user has access to its project."""
+    # First, get the item
     db_item = await db.get(TodoItem, item_id, options=[selectinload(TodoItem.project)])
     if not db_item:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Todo item with ID {item_id} not found"
         )
+
+    # Check if user has access to the current project
+    from src.services.todo_access_service import user_can_access_project
+    if db_item.project_id:
+        has_access = await user_can_access_project(
+            db, db_item.project_id, UUID(str(current_user.id))
+        )
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access to this item is forbidden"
+            )
+
+    # If project_id is changing, check access to the new project
     update_data = item_in.dict(exclude_unset=True)
     if "project_id" in update_data:
-        if update_data["project_id"] is not None:
-            project = await db.get(TodoProject, update_data["project_id"])
+        new_project_id = update_data["project_id"]
+        if new_project_id is not None:
+            # Check access to the new project
+            has_access = await user_can_access_project(
+                db, new_project_id, UUID(str(current_user.id))
+            )
+            if not has_access:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Access to the target project is forbidden"
+                )
+
+            # Verify project exists
+            project = await db.get(TodoProject, new_project_id)
             if not project:
                 raise HTTPException(
                     status_code=404, detail="Project not found")
-            db_item.project = project
+
+            # Update the project
+            db_item.project_id = new_project_id
         else:
-            db_item.project = None
+            # Project ID cannot be null
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="project_id cannot be null"
+            )
+
+        # Remove from update_data since we handled it
         del update_data["project_id"]
+
+    # Update the other fields
     for key, value in update_data.items():
         setattr(db_item, key, value)
+
     db_item.updated_at = datetime.utcnow()
     await db.commit()
     await db.refresh(db_item)
-    return db_item
+
+    # Manually convert item to dict to avoid async relationship issues
+    # Convert project to dict with string owner_id
+    project_dict = None
+    if db_item.project:
+        project_dict = {
+            "id": db_item.project.id,
+            "name": db_item.project.name,
+            "created_at": db_item.project.created_at,
+            "updated_at": db_item.project.updated_at,
+            "owner_id": str(db_item.project.owner_id),
+            "is_general": db_item.project.is_general
+        }
+
+    # Convert item to dict
+    item_dict = {
+        "id": db_item.id,
+        "name": db_item.name,
+        "description": db_item.description,
+        "is_closed": db_item.is_closed,
+        "shops": db_item.shops,
+        "project_id": db_item.project_id,
+        "created_at": db_item.created_at,
+        "updated_at": db_item.updated_at,
+        "completed_at": db_item.completed_at,
+        "project": project_dict
+    }
+
+    return item_dict
 
 
 @router.delete("/{item_id}", response_model=TodoItemSchema)
 async def delete_todo_item(
     *,
     db: AsyncSession = Depends(get_db),
-    item_id: int,
+    item_id: Annotated[int, Path(...)],
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_todo_items_permissions(Actions.DELETE))
 ) -> Any:
-    """Delete a todo item."""
+    """Delete a todo item if the user has access to its project."""
+    # First, get the item
     db_item = await db.get(TodoItem, item_id)
     if not db_item:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Todo item with ID {item_id} not found"
         )
+
+    # Check if user has access to the project
+    from src.services.todo_access_service import user_can_access_project
+    if db_item.project_id:
+        has_access = await user_can_access_project(
+            db, db_item.project_id, UUID(str(current_user.id))
+        )
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access to this item is forbidden"
+            )
+
+    # Delete the item
+    item_copy = TodoItemSchema.model_validate(db_item)
     await db.delete(db_item)
     await db.commit()
-    return db_item
+    return item_copy

--- a/src/api/v1/endpoints/todo_projects.py
+++ b/src/api/v1/endpoints/todo_projects.py
@@ -1,14 +1,28 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from typing import Annotated
+from fastapi import APIRouter, Depends, HTTPException, status, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy import update
+from sqlalchemy import update, and_
 from datetime import datetime
+from uuid import UUID
+
 from src.core.database import get_db
 from src.models.todo_project import TodoProject as TodoProjectModel
+from src.models.todo_project_collaborator import TodoProjectCollaborator
 from src.models.todo_item import TodoItem
-from src.schemas.todo_project import TodoProject, TodoProjectCreate, TodoProjectUpdate
+from src.models.user import User
+from src.schemas.todo_project import (
+    TodoProject, TodoProjectCreate, TodoProjectUpdate,
+    TodoProjectCollaboratorCreate, TodoProjectCollaboratorResponse
+)
 from src.auth.enums.actions import Actions
 from src.auth.permission_helpers import get_categories_permissions
+from src.auth.jwt_dependencies import get_current_active_user
+from src.api.v1.deps import (
+    require_project_access,
+    require_project_ownership,
+    prevent_general_project_modification
+)
 
 router = APIRouter()
 
@@ -16,23 +30,372 @@ router = APIRouter()
 @router.get("", response_model=list[TodoProject])
 async def list_todo_projects(
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_categories_permissions(Actions.READ))
 ):
-    result = await db.execute(select(TodoProjectModel))
-    return result.scalars().all()
+    """List all todo projects the user owns or collaborates on."""
+    # Get projects where user is owner
+    result = await db.execute(
+        select(TodoProjectModel).where(
+            TodoProjectModel.owner_id == UUID(str(current_user.id))
+        )
+    )
+    owned_projects = result.scalars().all()
+
+    # Get projects where user is collaborator
+    result = await db.execute(
+        select(TodoProjectModel)
+        .join(TodoProjectCollaborator)
+        .where(TodoProjectCollaborator.user_id == UUID(str(current_user.id)))
+    )
+    collab_projects = result.scalars().all()
+
+    # Combine and deduplicate
+    all_projects = {p.id: p for p in owned_projects}
+    for p in collab_projects:
+        if p.id not in all_projects:
+            all_projects[p.id] = p
+
+    # Manually create TodoProject objects to avoid async relationship issues
+    projects_list = []
+    for project in all_projects.values():
+        # Fetch collaborators manually for each project
+        result = await db.execute(
+            select(TodoProjectCollaborator).where(
+                TodoProjectCollaborator.project_id == project.id
+            )
+        )
+        collaborators = result.scalars().all()
+
+        # Convert collaborators to response format
+        collaborators_list = []
+        for collab in collaborators:
+            collaborators_list.append({
+                "user_id": collab.user_id,
+                "project_id": collab.project_id,
+                "created_at": collab.created_at
+            })
+
+        project_dict = {
+            "id": project.id,
+            "name": project.name,
+            "created_at": project.created_at,
+            "updated_at": project.updated_at,
+            "owner_id": project.owner_id,
+            "is_general": project.is_general,
+            "collaborators": collaborators_list
+        }
+        projects_list.append(project_dict)
+
+    return projects_list
 
 
 @router.post("", response_model=TodoProject, status_code=status.HTTP_201_CREATED)
 async def create_todo_project(
     todo_project: TodoProjectCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_categories_permissions(Actions.CREATE))
 ):
+    """Create a new todo project owned by the current user."""
     now = datetime.now()
     db_todo_project = TodoProjectModel(
         **todo_project.dict(),
         created_at=now,
+        updated_at=now,
+        owner_id=UUID(str(current_user.id)),
+        is_general=False
+    )
+    db.add(db_todo_project)
+    await db.commit()
+    await db.refresh(db_todo_project)
+    return db_todo_project
+
+
+@router.get("/{todo_project_id}", response_model=TodoProject)
+async def get_todo_project(
+    todo_project_id: Annotated[int, Path(...)],
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.READ))
+):
+    """Get a specific todo project if the user has access."""
+    # Check access
+    from src.services.todo_access_service import user_can_access_project
+    has_access = await user_can_access_project(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access to this project is forbidden"
+        )
+
+    todo_project = await db.get(TodoProjectModel, todo_project_id)
+    if not todo_project:
+        raise HTTPException(status_code=404, detail="Todo project not found")
+
+    # Fetch collaborators manually
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            TodoProjectCollaborator.project_id == todo_project_id
+        )
+    )
+    collaborators = result.scalars().all()
+
+    # Convert collaborators to response format
+    collaborators_list = []
+    for collab in collaborators:
+        collaborators_list.append({
+            "user_id": collab.user_id,
+            "project_id": collab.project_id,
+            "created_at": collab.created_at
+        })
+
+    # Manually create TodoProject object to avoid async relationship issues
+    project_dict = {
+        "id": todo_project.id,
+        "name": todo_project.name,
+        "created_at": todo_project.created_at,
+        "updated_at": todo_project.updated_at,
+        "owner_id": todo_project.owner_id,
+        "is_general": todo_project.is_general,
+        "collaborators": collaborators_list
+    }
+
+    return project_dict
+
+
+@router.put("/{todo_project_id}", response_model=TodoProject)
+async def update_todo_project(
+    todo_project_update: TodoProjectUpdate,
+    todo_project_id: Annotated[int, Path(...)],
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.UPDATE))
+):
+    """Update a todo project if the user has access and it's not a General project."""
+    # Check access
+    from src.services.todo_access_service import user_can_access_project, is_general_project
+    has_access = await user_can_access_project(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access to this project is forbidden"
+        )
+
+    # Check if General project
+    is_general = await is_general_project(db, todo_project_id)
+    if is_general:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The General project cannot be modified or deleted"
+        )
+
+    todo_project = await db.get(TodoProjectModel, todo_project_id)
+    if not todo_project:
+        raise HTTPException(status_code=404, detail="Todo project not found")
+
+    for key, value in todo_project_update.dict(exclude_unset=True).items():
+        setattr(todo_project, key, value)
+
+    todo_project.updated_at = datetime.now()
+    await db.commit()
+    await db.refresh(todo_project)
+    return todo_project
+
+
+@router.delete("/{todo_project_id}", status_code=204)
+async def delete_todo_project(
+    todo_project_id: Annotated[int, Path(...)],
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.DELETE))
+):
+    """Delete a todo project if the user is the owner and it's not a General project."""
+    # Check ownership
+    from src.services.todo_access_service import user_is_project_owner, is_general_project
+    is_owner = await user_is_project_owner(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not is_owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only project owners can perform this action"
+        )
+
+    # Check if General project
+    is_general = await is_general_project(db, todo_project_id)
+    if is_general:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The General project cannot be modified or deleted"
+        )
+
+    todo_project = await db.get(TodoProjectModel, todo_project_id)
+    if not todo_project:
+        raise HTTPException(status_code=404, detail="Todo project not found")
+
+    await db.delete(todo_project)
+    await db.commit()
+
+
+# Collaborator Management Endpoints
+
+@router.post("/{todo_project_id}/collaborators", response_model=TodoProjectCollaboratorResponse, status_code=status.HTTP_201_CREATED)
+async def add_collaborator(
+    collaborator_data: TodoProjectCollaboratorCreate,
+    todo_project_id: Annotated[int, Path(...)],
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.UPDATE))
+):
+    """Add a collaborator to a todo project."""
+    # Check ownership
+    from src.services.todo_access_service import user_is_project_owner
+    is_owner = await user_is_project_owner(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not is_owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only project owners can perform this action"
+        )
+
+    # Check if project exists
+    project = await db.get(TodoProjectModel, todo_project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Todo project not found")
+
+    # Check if user exists
+    user = await db.get(User, collaborator_data.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Check if user is already the owner
+    if user.id == project.owner_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User is already the project owner"
+        )
+
+    # Check if collaboration already exists
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            and_(
+                TodoProjectCollaborator.project_id == todo_project_id,
+                TodoProjectCollaborator.user_id == collaborator_data.user_id
+            )
+        )
+    )
+    existing = result.scalars().first()
+
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User is already a collaborator on this project"
+        )
+
+    # Create collaboration
+    now = datetime.now()
+    db_collaborator = TodoProjectCollaborator(
+        project_id=todo_project_id,
+        user_id=collaborator_data.user_id,
+        created_at=now,
         updated_at=now
+    )
+
+    db.add(db_collaborator)
+    await db.commit()
+    await db.refresh(db_collaborator)
+
+    return db_collaborator
+
+
+@router.get("/{todo_project_id}/collaborators", response_model=list[TodoProjectCollaboratorResponse])
+async def list_collaborators(
+    todo_project_id: Annotated[int, Path(...)],
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.READ))
+):
+    """List all collaborators for a todo project."""
+    # Check access
+    from src.services.todo_access_service import user_can_access_project
+    has_access = await user_can_access_project(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access to this project is forbidden"
+        )
+
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            TodoProjectCollaborator.project_id == todo_project_id
+        )
+    )
+    return result.scalars().all()
+
+
+@router.delete("/{todo_project_id}/collaborators/{user_id}", status_code=204)
+async def remove_collaborator(
+    user_id: UUID,
+    todo_project_id: Annotated[int, Path(...)],
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.DELETE))
+):
+    """Remove a collaborator from a todo project."""
+    # Check ownership
+    from src.services.todo_access_service import user_is_project_owner
+    is_owner = await user_is_project_owner(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not is_owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only project owners can perform this action"
+        )
+
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            and_(
+                TodoProjectCollaborator.project_id == todo_project_id,
+                TodoProjectCollaborator.user_id == user_id
+            )
+        )
+    )
+    collaborator = result.scalars().first()
+
+    if not collaborator:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Collaborator not found"
+        )
+
+    await db.delete(collaborator)
+    await db.commit()
+
+
+@router.post("", response_model=TodoProject, status_code=status.HTTP_201_CREATED)
+async def create_todo_project(
+    todo_project: TodoProjectCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.CREATE))
+):
+    """Create a new todo project owned by the current user."""
+    now = datetime.now()
+    db_todo_project = TodoProjectModel(
+        **todo_project.dict(),
+        created_at=now,
+        updated_at=now,
+        owner_id=UUID(str(current_user.id)),
+        is_general=False
     )
     db.add(db_todo_project)
     await db.commit()
@@ -44,8 +407,21 @@ async def create_todo_project(
 async def get_todo_project(
     todo_project_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_categories_permissions(Actions.READ))
 ):
+    """Get a specific todo project if the user has access."""
+    # Check access
+    from src.services.todo_access_service import user_can_access_project
+    has_access = await user_can_access_project(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access to this project is forbidden"
+        )
+
     todo_project = await db.get(TodoProjectModel, todo_project_id)
     if not todo_project:
         raise HTTPException(status_code=404, detail="Todo project not found")
@@ -57,13 +433,36 @@ async def update_todo_project(
     todo_project_id: int,
     todo_project_update: TodoProjectUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_categories_permissions(Actions.UPDATE))
 ):
+    """Update a todo project if the user has access and it's not a General project."""
+    # Check access
+    from src.services.todo_access_service import user_can_access_project, is_general_project
+    has_access = await user_can_access_project(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access to this project is forbidden"
+        )
+
+    # Check if General project
+    is_general = await is_general_project(db, todo_project_id)
+    if is_general:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The General project cannot be modified or deleted"
+        )
+
     todo_project = await db.get(TodoProjectModel, todo_project_id)
     if not todo_project:
         raise HTTPException(status_code=404, detail="Todo project not found")
+
     for key, value in todo_project_update.dict(exclude_unset=True).items():
         setattr(todo_project, key, value)
+
     todo_project.updated_at = datetime.now()
     await db.commit()
     await db.refresh(todo_project)
@@ -74,16 +473,171 @@ async def update_todo_project(
 async def delete_todo_project(
     todo_project_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
     _: None = Depends(get_categories_permissions(Actions.DELETE))
 ):
+    """Delete a todo project if the user is the owner and it's not a General project."""
+    # Check ownership
+    from src.services.todo_access_service import user_is_project_owner, is_general_project
+    is_owner = await user_is_project_owner(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not is_owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only project owners can perform this action"
+        )
+
+    # Check if General project
+    is_general = await is_general_project(db, todo_project_id)
+    if is_general:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The General project cannot be modified or deleted"
+        )
+
     todo_project = await db.get(TodoProjectModel, todo_project_id)
     if not todo_project:
         raise HTTPException(status_code=404, detail="Todo project not found")
-    # Set project_id to None for all related todo items
-    await db.execute(
-        update(TodoItem)
-        .where(TodoItem.project_id == todo_project_id)
-        .values(project_id=None)
-    )
+
     await db.delete(todo_project)
+    await db.commit()
+
+
+# Collaborator Management Endpoints
+
+@router.post("/{todo_project_id}/collaborators", response_model=TodoProjectCollaboratorResponse, status_code=status.HTTP_201_CREATED)
+async def add_collaborator(
+    todo_project_id: int,
+    collaborator_data: TodoProjectCollaboratorCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.UPDATE))
+):
+    """Add a collaborator to a todo project."""
+    # Check ownership
+    from src.services.todo_access_service import user_is_project_owner
+    is_owner = await user_is_project_owner(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not is_owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only project owners can perform this action"
+        )
+
+    # Check if project exists
+    project = await db.get(TodoProjectModel, todo_project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Todo project not found")
+
+    # Check if user exists
+    user = await db.get(User, collaborator_data.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Check if user is already the owner
+    if user.id == project.owner_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User is already the project owner"
+        )
+
+    # Check if collaboration already exists
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            and_(
+                TodoProjectCollaborator.project_id == todo_project_id,
+                TodoProjectCollaborator.user_id == collaborator_data.user_id
+            )
+        )
+    )
+    existing = result.scalars().first()
+
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User is already a collaborator on this project"
+        )
+
+    # Create collaboration
+    now = datetime.now()
+    db_collaborator = TodoProjectCollaborator(
+        project_id=todo_project_id,
+        user_id=collaborator_data.user_id,
+        created_at=now,
+        updated_at=now
+    )
+
+    db.add(db_collaborator)
+    await db.commit()
+    await db.refresh(db_collaborator)
+
+    return db_collaborator
+
+
+@router.get("/{todo_project_id}/collaborators", response_model=list[TodoProjectCollaboratorResponse])
+async def list_collaborators(
+    todo_project_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.READ))
+):
+    """List all collaborators for a todo project."""
+    # Check access
+    from src.services.todo_access_service import user_can_access_project
+    has_access = await user_can_access_project(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access to this project is forbidden"
+        )
+
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            TodoProjectCollaborator.project_id == todo_project_id
+        )
+    )
+    return result.scalars().all()
+
+
+@router.delete("/{todo_project_id}/collaborators/{user_id}", status_code=204)
+async def remove_collaborator(
+    todo_project_id: int,
+    user_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    _: None = Depends(get_categories_permissions(Actions.DELETE))
+):
+    """Remove a collaborator from a todo project."""
+    # Check ownership
+    from src.services.todo_access_service import user_is_project_owner
+    is_owner = await user_is_project_owner(
+        db, todo_project_id, UUID(str(current_user.id))
+    )
+    if not is_owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only project owners can perform this action"
+        )
+
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            and_(
+                TodoProjectCollaborator.project_id == todo_project_id,
+                TodoProjectCollaborator.user_id == user_id
+            )
+        )
+    )
+    collaborator = result.scalars().first()
+
+    if not collaborator:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Collaborator not found"
+        )
+
+    await db.delete(collaborator)
     await db.commit()

--- a/src/models/todo_item.py
+++ b/src/models/todo_item.py
@@ -13,5 +13,6 @@ class TodoItem(BaseModel):
     is_closed = Column(Boolean, default=False)
     completed_at = Column(DateTime(timezone=True), nullable=True)
     shops = Column(String(255), nullable=True)
-    project_id = Column(Integer, ForeignKey("todo_projects.id", ondelete="SET NULL"), nullable=True)
+    project_id = Column(Integer, ForeignKey(
+        "todo_projects.id", ondelete="CASCADE"), nullable=False)
     project = relationship("TodoProject", back_populates="items")

--- a/src/models/todo_project.py
+++ b/src/models/todo_project.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, ForeignKey, Boolean
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base
 
@@ -8,7 +9,16 @@ class TodoProject(Base):
     __tablename__ = "todo_projects"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, nullable=False, unique=True)
+    name = Column(String, nullable=False)
     created_at: Mapped[datetime] = mapped_column(nullable=False)
     updated_at: Mapped[datetime] = mapped_column(nullable=False)
-    items = relationship("TodoItem", back_populates="project")
+    owner_id = Column(UUID(as_uuid=True), ForeignKey(
+        "users.id"), nullable=False)
+    is_general = Column(Boolean, default=False, nullable=False)
+
+    # Relationships
+    items = relationship("TodoItem", back_populates="project",
+                         cascade="all, delete-orphan")
+    owner = relationship("User", back_populates="todo_projects")
+    collaborators = relationship(
+        "TodoProjectCollaborator", back_populates="project", cascade="all, delete-orphan")

--- a/src/models/todo_project_collaborator.py
+++ b/src/models/todo_project_collaborator.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from .base import BaseModel
+
+
+class TodoProjectCollaborator(BaseModel):
+    __tablename__ = "todo_project_collaborators"
+
+    project_id = Column(Integer, ForeignKey(
+        "todo_projects.id", ondelete="CASCADE"), primary_key=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey(
+        "users.id", ondelete="CASCADE"), primary_key=True)
+
+    # Relationships
+    project = relationship("TodoProject", back_populates="collaborators")
+    user = relationship("User", back_populates="todo_collaborations")
+
+    __table_args__ = (
+        UniqueConstraint('project_id', 'user_id',
+                         name='unique_project_user_collaboration'),
+    )

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -28,6 +28,10 @@ class User(BaseModel):
         "AccessToken", back_populates="user", cascade="all, delete-orphan")
     refresh_tokens = relationship(
         "RefreshToken", back_populates="user", cascade="all, delete-orphan")
+    todo_projects = relationship(
+        "TodoProject", back_populates="owner", cascade="all, delete-orphan")
+    todo_collaborations = relationship(
+        "TodoProjectCollaborator", back_populates="user", cascade="all, delete-orphan")
 
     # Self-referential relationship for created_by
     creator = relationship("User", remote_side=[id], backref="created_users")

--- a/src/schemas/todo_item.py
+++ b/src/schemas/todo_item.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 from src.schemas.todo_project import TodoProject
 
 
@@ -8,7 +8,7 @@ class TodoItemBase(BaseModel):
     name: str
     description: Optional[str] = None
     shops: Optional[str] = None
-    project_id: Optional[int] = None
+    project_id: int  # Now required
 
 
 class TodoItemCreate(TodoItemBase):
@@ -24,13 +24,30 @@ class TodoItemUpdate(BaseModel):
     project_id: Optional[int] = None
 
 
+# Use a reduced TodoProject schema to avoid circular dependencies
+class SimpleTodoProject(BaseModel):
+    id: int
+    name: str
+    created_at: datetime
+    updated_at: datetime
+    owner_id: str  # Change type to str to handle UUID conversion
+    is_general: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer('owner_id')
+    def serialize_owner_id(self, owner_id):
+        return str(owner_id) if owner_id else None
+
+
 class TodoItemInDBBase(TodoItemBase):
     id: int
     is_closed: bool
     created_at: datetime
     updated_at: datetime
     completed_at: Optional[datetime] = None
-    project: Optional[TodoProject] = None
+    # Use the simplified project schema
+    project: Optional[SimpleTodoProject] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/schemas/todo_project.py
+++ b/src/schemas/todo_project.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict
+from typing import List, Optional
+from uuid import UUID
+from pydantic import BaseModel, ConfigDict, field_serializer, Field
 
 
 class TodoProjectBase(BaseModel):
@@ -14,13 +16,37 @@ class TodoProjectUpdate(TodoProjectBase):
     pass
 
 
+class TodoProjectCollaboratorBase(BaseModel):
+    user_id: UUID
+
+
+class TodoProjectCollaboratorCreate(TodoProjectCollaboratorBase):
+    pass
+
+
+class TodoProjectCollaboratorResponse(TodoProjectCollaboratorBase):
+    project_id: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class TodoProjectInDBBase(TodoProjectBase):
     id: int
     created_at: datetime
     updated_at: datetime
+    owner_id: UUID
+    is_general: bool
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class TodoProject(TodoProjectInDBBase):
-    pass
+    # Set a default empty list instead of trying to load the relationship
+    collaborators: List[TodoProjectCollaboratorResponse] = Field(
+        default_factory=list)
+
+    # This serializer ensures we always return a list even if the field is None
+    @field_serializer('collaborators')
+    def serialize_collaborators(self, collaborators: Optional[List[TodoProjectCollaboratorResponse]]) -> List[TodoProjectCollaboratorResponse]:
+        return collaborators or []

--- a/src/services/todo_access_service.py
+++ b/src/services/todo_access_service.py
@@ -1,0 +1,223 @@
+"""Access control service for Todo app collaboration feature."""
+
+from sqlalchemy import and_
+from typing import Optional
+from uuid import UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy import and_, or_
+
+from src.models.todo_project import TodoProject
+from src.models.todo_project_collaborator import TodoProjectCollaborator
+from src.models.todo_item import TodoItem
+
+
+async def user_can_access_project(db: AsyncSession, project_id: int, user_id: UUID) -> bool:
+    """Check if a user can access a project (as owner or collaborator)."""
+    # First check if user is the owner
+    result = await db.execute(
+        select(TodoProject).where(
+            and_(
+                TodoProject.id == project_id,
+                TodoProject.owner_id == user_id
+            )
+        )
+    )
+    if result.scalars().first():
+        return True
+
+    # Then check if user is a collaborator
+    result = await db.execute(
+        select(TodoProjectCollaborator).where(
+            and_(
+                TodoProjectCollaborator.project_id == project_id,
+                TodoProjectCollaborator.user_id == user_id
+            )
+        )
+    )
+    if result.scalars().first():
+        return True
+
+    return False
+
+
+async def user_is_project_owner(db: AsyncSession, project_id: int, user_id: UUID) -> bool:
+    """Check if a user is the owner of a project."""
+    result = await db.execute(
+        select(TodoProject).where(
+            and_(
+                TodoProject.id == project_id,
+                TodoProject.owner_id == user_id
+            )
+        )
+    )
+    return result.scalars().first() is not None
+
+
+async def is_general_project(db: AsyncSession, project_id: int) -> bool:
+    """Check if a project is a General project."""
+    result = await db.execute(
+        select(TodoProject).where(
+            and_(
+                TodoProject.id == project_id,
+                TodoProject.is_general == True
+            )
+        )
+    )
+    return result.scalars().first() is not None
+
+
+async def user_can_access_item(db: AsyncSession, item_id: int, user_id: UUID) -> bool:
+    """Check if a user can access a todo item (by having access to its project)."""
+    # Get the item's project_id
+    result = await db.execute(
+        select(TodoItem.project_id).where(TodoItem.id == item_id)
+    )
+    project_id = result.scalar_one_or_none()
+
+    if project_id is None:
+        return False
+
+    # Check if user can access the project
+    return await user_can_access_project(db, project_id, user_id)
+
+
+async def get_accessible_project_ids(db: AsyncSession, user_id: UUID) -> list[int]:
+    """Get all project IDs that a user can access (owned or collaborated)."""
+    # Get projects where user is owner
+    result = await db.execute(
+        select(TodoProject.id).where(TodoProject.owner_id == user_id)
+    )
+    owned_project_ids = result.scalars().all()
+
+    # Get projects where user is collaborator
+    result = await db.execute(
+        select(TodoProjectCollaborator.project_id).where(
+            TodoProjectCollaborator.user_id == user_id
+        )
+    )
+    collab_project_ids = result.scalars().all()
+
+    # Combine and deduplicate
+    all_project_ids = set(owned_project_ids) | set(collab_project_ids)
+
+    return list(all_project_ids)
+
+
+async def user_can_access_project(
+    db: AsyncSession,
+    project_id: int,
+    user_id: UUID
+) -> bool:
+    """
+    Check if a user has access to a project (as owner or collaborator).
+
+    Args:
+        db: Database session
+        project_id: ID of the project to check
+        user_id: ID of the user
+
+    Returns:
+        True if user is owner or collaborator, False otherwise
+    """
+    # Check if user is the owner
+    result = await db.execute(
+        select(TodoProject)
+        .where(and_(
+            TodoProject.id == project_id,
+            TodoProject.owner_id == user_id
+        ))
+    )
+    project = result.scalars().first()
+
+    if project:
+        return True
+
+    # Check if user is a collaborator
+    result = await db.execute(
+        select(TodoProjectCollaborator)
+        .where(and_(
+            TodoProjectCollaborator.project_id == project_id,
+            TodoProjectCollaborator.user_id == user_id
+        ))
+    )
+    collaborator = result.scalars().first()
+
+    return collaborator is not None
+
+
+async def user_can_access_item(
+    db: AsyncSession,
+    item_id: int,
+    user_id: UUID
+) -> bool:
+    """
+    Check if a user has access to an item (via project ownership or collaboration).
+
+    Args:
+        db: Database session
+        item_id: ID of the item to check
+        user_id: ID of the user
+
+    Returns:
+        True if user has access, False otherwise
+    """
+    # Get the item's project ID
+    result = await db.execute(
+        select(TodoItem.project_id)
+        .where(TodoItem.id == item_id)
+    )
+    project_id = result.scalar()
+
+    if not project_id:
+        return False
+
+    # Check access to the project
+    return await user_can_access_project(db, project_id, user_id)
+
+
+async def user_is_project_owner(
+    db: AsyncSession,
+    project_id: int,
+    user_id: UUID
+) -> bool:
+    """
+    Check if a user is the owner of a project.
+
+    Args:
+        db: Database session
+        project_id: ID of the project to check
+        user_id: ID of the user
+
+    Returns:
+        True if user is the owner, False otherwise
+    """
+    result = await db.execute(
+        select(TodoProject)
+        .where(and_(
+            TodoProject.id == project_id,
+            TodoProject.owner_id == user_id
+        ))
+    )
+    return result.scalars().first() is not None
+
+
+async def is_general_project(
+    db: AsyncSession,
+    project_id: int
+) -> bool:
+    """
+    Check if a project is a "General" project.
+
+    Args:
+        db: Database session
+        project_id: ID of the project to check
+
+    Returns:
+        True if project is a General project, False otherwise
+    """
+    result = await db.execute(
+        select(TodoProject.is_general)
+        .where(TodoProject.id == project_id)
+    )
+    return result.scalar() or False

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -292,6 +292,22 @@ async def create_user(
     await db.commit()
     await db.refresh(new_user)
 
+    # Create a General project for the new user
+    from src.models.todo_project import TodoProject
+    from datetime import datetime
+
+    now = datetime.utcnow()
+    general_project = TodoProject(
+        name="General",
+        description="Default project for todo items",
+        owner_id=new_user.id,
+        is_general=True,
+        created_at=now,
+        updated_at=now
+    )
+    db.add(general_project)
+    await db.commit()
+
     # Load role relationship
     await db.refresh(new_user, ["role"])
 


### PR DESCRIPTION
This pull request introduces a collaboration feature to the Todo app, focusing on project ownership, project collaborators, and fine-grained access control for todo items. It includes a major database migration, new API dependencies for access control, and significant updates to the todo items API endpoints to enforce these new permissions.

**Database schema and migration:**

- Added a new `todo_project_collaborators` table to support project-level collaboration and modified the `todo_projects` table to include `owner_id` and `is_general` fields. The migration also ensures all projects have an owner, creates a "General" project for each user, and enforces that all todo items belong to a project. Foreign key constraints are updated for proper cascading behavior.
- Changed the `project_id` column in `todo_items` to be non-nullable and to use `CASCADE` on delete, ensuring every item is always associated with a project.

**API and access control enhancements:**

- Introduced new dependency functions in `src/api/v1/deps.py` to enforce project and item access, project ownership, and to prevent modification of "General" projects. These dependencies are designed to be reusable across endpoints.
- Updated all todo item endpoints in `src/api/v1/endpoints/todo_items.py` to enforce that users can only view, create, update, or delete items in projects they have access to (as owner or collaborator). The endpoints now strictly check permissions and return errors when access is denied.
- Responses for todo item endpoints now consistently return dictionaries instead of ORM objects, ensuring correct serialization and including project ownership information.

**Documentation:**

- Added documentation on how to structure and store thoughts and summaries in the `.ai` folder, including naming conventions for requirements, notes, and development plans.